### PR TITLE
Add CI workflows for backend and frontend

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,0 +1,39 @@
+name: Backend CI
+
+on:
+  push:
+    paths:
+      - "backend/**"
+      - "chatbot/**"
+    branches: [main]
+  pull_request:
+    paths:
+      - "backend/**"
+      - "chatbot/**"
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: |
+          cd backend
+          python manage.py test
+        env:
+          DEBUG: True
+          HUGGINGFACE_API_KEY: ${{ secrets.HUGGINGFACE_API_KEY }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,37 @@
+name: Frontend CI
+
+on:
+  push:
+    paths:
+      - "frontend/**"
+    branches: [main]
+  pull_request:
+    paths:
+      - "frontend/**"
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test -- --watchAll=false


### PR DESCRIPTION
This pull request introduces continuous integration (CI) workflows for both the backend and frontend components of the project. The changes add GitHub Actions configurations to automatically run tests and build processes on code pushes and pull requests.

CI workflow configurations:

* [`.github/workflows/backend.yml`](diffhunk://#diff-4221e7060cb5692b5e8656f8f092468895f4bc8804397e8de7cb4cfdf8d95024R1-R39): Added a CI workflow to run tests for the backend and chatbot components using Python 3.9. The workflow installs dependencies and runs tests with specific environment variables.
* [`.github/workflows/frontend.yml`](diffhunk://#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeR1-R37): Added a CI workflow to build and test the frontend component using Node.js 16. The workflow installs dependencies, builds the project, and runs tests.