### PR TITLE
Update CI/CD workflow name and simplify backend job configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI/CD for RubikLog
+name: CI/CD for AmazeBot
 
 on:
   push:
@@ -20,22 +20,7 @@ jobs:
   backend:
     name: Backend CI
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:14
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: shreyuu
-          POSTGRES_DB: rubiklogdb
-        options: >-
-          --health-cmd="pg_isready -U postgres"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-        ports:
-          - 5432:5432
     env:
-      DATABASE_URL: postgres://postgres:shreyuu@localhost:5432/rubiklogdb
       DEBUG: True
       HUGGINGFACE_API_KEY: ${{ secrets.HUGGINGFACE_API_KEY }}
     steps:
@@ -52,16 +37,17 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+        working-directory: .
 
       - name: Run migrations
-        working-directory: backend
         run: |
           python manage.py migrate
+        working-directory: .
 
       - name: Run backend tests
-        working-directory: backend
         run: |
           python manage.py test
+        working-directory: .
 
   frontend:
     name: Frontend CI
@@ -84,8 +70,7 @@ jobs:
         run: npm ci
 
       - name: Run frontend tests
-        run: |
-          CI=true npm test -- --watchAll=false
+        run: CI=true npm test -- --watchAll=false
 
       - name: Build frontend
         run: npm run build


### PR DESCRIPTION
This pull request includes several changes to the CI/CD workflow configuration for AmazeBot. The most significant changes involve renaming the workflow, removing the PostgreSQL service, and standardizing the working directory for various steps.

Changes to CI/CD workflow configuration:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL1-R1): Renamed the workflow from "CI/CD for RubikLog" to "CI/CD for AmazeBot".
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL23-L38): Removed the PostgreSQL service configuration from the backend job.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR40-R50): Standardized the working directory for the backend job steps to the root directory.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL87-R73): Simplified the frontend job by removing redundant `working-directory` specifications.